### PR TITLE
Simplify view layer

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -82,62 +82,48 @@
     import '@internetarchive/ia-menu-slider/ia-menu-slider';
     import bookmarksController from './bookmarks_controller.js';
 
-    const bookmarks = [{
-      note: 'This is a long comment I left about this bookmark in order to test out the display in the panel on the side of the bookreader.',
-      color: 0,
-      id: '2',
-      leafNum: '2',
-      page: '-2-',
-      thumbnail: '//placehold.it/320x496/e5e5e5/06c',
-    },
-    {
-      note: 'This is a long comment I left about this bookmark in order to test out the display in the panel on the side of the bookreader.',
-      color: 0,
-      id: '51',
-      leafNum: '51',
-      page: 24,
-      thumbnail: '//placehold.it/320x496/e5e5e5/06c',
-    },
-    {
-      note: 'Interesting quote here regarding the division of labor',
-      color: 2,
-      id: '80',
-      leafNum: '80',
-      page: 53,
-      thumbnail: '//placehold.it/320x496/06c/fff',
-    },
-    {
-      note: 'Interesting quote here regarding the division of labor',
-      color: 0,
-      id: '86',
-      leafNum: '86',
-      page: 59,
-      thumbnail: '//placehold.it/320x496/e5e5e5/06c',
-    },
-    {
-      note: '',
-      color: 2,
-      id: '87',
-      leafNum: '87',
-      page: 60,
-      thumbnail: '//placehold.it/320x496/e5e5e5/06c',
-    },
-    {
-      note: '',
-      color: 1,
-      id: '139',
-      leafNum: '139',
-      page: 112,
-      thumbnail: '//placehold.it/320x496/06c/fff',
-    },
-    {
-      note: '',
-      color: 0,
-      id: '142',
-      leafNum: '142',
-      page: 115,
-      thumbnail: '//placehold.it/320x496/06c/fff',
-    }];
+    const bookmarks = {
+      86: {
+        note: 'Interesting quote here regarding the division of labor',
+        color: 0,
+        id: '86',
+        leafNum: '86',
+        page: 59,
+        thumbnail: '//placehold.it/320x496/e5e5e5/06c',
+      },
+      51: {
+        note: 'This is a long comment I left about this bookmark in order to test out the display in the panel on the side of the bookreader.',
+        color: 0,
+        id: 51,
+        leafNum: 51,
+        page: 24,
+        thumbnail: '//placehold.it/320x496/e5e5e5/06c',
+      },
+      2: {
+        note: 'This is a long comment I left about this bookmark in order to test out the display in the panel on the side of the bookreader.',
+        color: 0,
+        id: 2,
+        leafNum: 2,
+        page: '-2-',
+        thumbnail: '//placehold.it/320x496/e5e5e5/06c',
+      },
+      80: {
+        note: 'Interesting quote here regarding the division of labor',
+        color: 2,
+        id: '80',
+        leafNum: '80',
+        page: 53,
+        thumbnail: '//placehold.it/320x496/06c/fff',
+      },
+      139: {
+        note: '',
+        color: 1,
+        id: 139,
+        leafNum: 139,
+        page: 112,
+        thumbnail: '//placehold.it/320x496/06c/fff',
+      },
+    };
 
     const bookmarkColors = [{
       id: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmarks-list",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmarks-list",
-  "version": "0.1.11-alpha2",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmarks-list",
-  "version": "0.1.11-alpha1",
+  "version": "0.1.11-alpha2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmarks-list",
-  "version": "0.1.10",
+  "version": "0.1.11-alpha1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmarks-list",
-  "version": "0.1.11-alpha2",
+  "version": "0.2.0",
   "description": "Bookmarks list component for ia-menu-slider",
   "author": "Shane Riley, Isa Herico Velasco, Internet Archive",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmarks-list",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Bookmarks list component for ia-menu-slider",
   "author": "Shane Riley, Isa Herico Velasco, Internet Archive",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmarks-list",
-  "version": "0.1.10",
+  "version": "0.1.11-alpha1",
   "description": "Bookmarks list component for ia-menu-slider",
   "author": "Shane Riley, Isa Herico Velasco, Internet Archive",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-bookmarks-list",
-  "version": "0.1.11-alpha1",
+  "version": "0.1.11-alpha2",
   "description": "Bookmarks list component for ia-menu-slider",
   "author": "Shane Riley, Isa Herico Velasco, Internet Archive",
   "license": "AGPL-3.0-only",

--- a/src/ia-bookmarks-list.js
+++ b/src/ia-bookmarks-list.js
@@ -18,8 +18,6 @@ export class IABookmarksList extends LitElement {
       bookmarks: { type: Object },
       editedBookmark: { type: Object },
       renderHeader: { type: Boolean },
-
-      sortedBookmarks: { type: Array },
     };
   }
 
@@ -29,24 +27,8 @@ export class IABookmarksList extends LitElement {
     this.bookmarkColors = [];
     this.defaultBookmarkColor = {};
     this.bookmarks = {};
-    this.sortedBookmarks = [];
     this.editedBookmark = {};
     this.renderHeader = false;
-  }
-
-  firstUpdated() {
-    this.sortedBookmarks = this.sortBookmarks(this.bookmarks);
-  }
-
-  updated(changed) {
-    const activeBookmarkChanged = changed.has('activeBookmarkID');
-    console.log('IA BOOKMARKS LIST UPDATED : activeBookmarkChanged ', activeBookmarkChanged);
-    console.log('IA BOOKMARKS LIST UPDATED : this.activeBookmarkChanged ', this.activeBookmarkID);
-
-    if (activeBookmarkChanged) { /* can be zero */
-      this.shadowRoot.querySelector('.content.active').scrollIntoView();
-    }
-    // this.sortedBookmarks = this.sortBookmarks(this.bookmarks);
   }
 
   emitEditEvent(e, bookmark) {
@@ -125,6 +107,7 @@ export class IABookmarksList extends LitElement {
       <li
         @click=${() => this.emitSelectedEvent(bookmark)}
         tabindex="0"
+        data-pageIndex=${bookmark.id}
       >
         <div class="separator"></div>
         <div class="content ${activeClass}">
@@ -161,6 +144,16 @@ export class IABookmarksList extends LitElement {
     `;
   }
 
+  sortBookmarks() {
+    const sortedKeys = Object.keys(this.bookmarks).sort((a, b) => {
+      if (+a > +b) { return 1; }
+      if (+a < +b) { return -1; }
+      return 0;
+    });
+    const sortedBookmarks = sortedKeys.map(key => this.bookmarks[key]);
+    return sortedBookmarks;
+  }
+
   get bookmarksCount() {
     const count = this.bookmarks.length;
     return html`<small>(${count})</small>`;
@@ -175,26 +168,18 @@ export class IABookmarksList extends LitElement {
     </header>`;
   }
 
-  sortBookmarks() {
-    const sortedKeys = Object.keys(this.bookmarks).sort((a, b) => {
-      if (+a > +b) { return 1; }
-      if (+a < +b) { return -1; }
-      return 0;
-    });
-
-    const sortedBookmarks = sortedKeys.map(key => this.bookmarks[key]);
-
-    return sortedBookmarks;
+  get bookmarkslist() {
+    const sortedBookmarks = this.sortBookmarks();
+    return html`<ul>
+        ${repeat(sortedBookmarks, bookmark => bookmark?.id, this.bookmarkItem.bind(this))}
+        <div class="separator"></div>
+      </ul>`;
   }
 
   render() {
-    console.log('RENDER, sortedbookmarker', this.sortedBookmarks);
     return html`
       ${this.renderHeader ? this.headerSection : nothing}
-      <ul>
-        ${this.sortedBookmarks.length ? repeat(this.sortedBookmarks, bookmark => bookmark.id, this.bookmarkItem.bind(this)) : nothing}
-        <div class="separator"></div>
-      </ul>
+      ${Object.keys(this.bookmarks).length ? this.bookmarkslist : nothing}
     `;
   }
 }

--- a/src/ia-bookmarks-list.js
+++ b/src/ia-bookmarks-list.js
@@ -36,13 +36,15 @@ export class IABookmarksList extends LitElement {
 
   firstUpdated() {
     this.sortedBookmarks = this.sortBookmarks(this.bookmarks);
-    console.log('FIRST UPDATED', this.sortedBookmarks);
   }
 
   updated(changed) {
     const activeBookmarkChanged = changed.has('activeBookmarkID');
-    if (activeBookmarkChanged && (this.activeBookmarkID !== undefined)) { /* can be zero */
-      this.shadowRoot.querySelector('.active').scrollIntoView();
+    console.log('IA BOOKMARKS LIST UPDATED : activeBookmarkChanged ', activeBookmarkChanged);
+    console.log('IA BOOKMARKS LIST UPDATED : this.activeBookmarkChanged ', this.activeBookmarkID);
+
+    if (activeBookmarkChanged) { /* can be zero */
+      this.shadowRoot.querySelector('.content.active').scrollIntoView();
     }
     // this.sortedBookmarks = this.sortBookmarks(this.bookmarks);
   }

--- a/src/ia-bookmarks-list.js
+++ b/src/ia-bookmarks-list.js
@@ -17,8 +17,6 @@ export class IABookmarksList extends LitElement {
       defaultBookmarkColor: { type: Object },
       bookmarks: { type: Array },
       editedBookmark: { type: Object },
-      renderAddBookmarkButton: { type: Boolean },
-      disableAddBookmarkButton: { type: Boolean },
       renderHeader: { type: Boolean },
     };
   }
@@ -30,8 +28,6 @@ export class IABookmarksList extends LitElement {
     this.defaultBookmarkColor = {};
     this.bookmarks = [];
     this.editedBookmark = {};
-    this.renderAddBookmarkButton = true;
-    this.disableAddBookmarkButton = false;
     this.renderHeader = false;
   }
 
@@ -161,24 +157,13 @@ export class IABookmarksList extends LitElement {
     </header>`;
   }
 
-  get addBookmarkButton() {
-    return html`<button class="add-bookmark" @click=${this.emitAddBookmark}>Add bookmark</button>`;
-  }
-
-  get addBookmarkDisabledButton() {
-    return html`<button disabled="disabled" class="add-bookmark" @click=${this.emitAddBookmark}>Add bookmark</button>`;
-  }
-
   render() {
-    const addBookmarkCTA = this.disableAddBookmarkButton
-      ? this.addBookmarkDisabledButton : this.addBookmarkButton;
     return html`
       ${this.renderHeader ? this.headerSection : nothing}
       <ul>
         ${this.bookmarks.length ? repeat(this.bookmarks, bookmark => bookmark.id, this.bookmarkItem.bind(this)) : nothing}
         <div class="separator"></div>
       </ul>
-      ${this.renderAddBookmarkButton ? addBookmarkCTA : nothing}
     `;
   }
 }

--- a/src/ia-bookmarks-list.js
+++ b/src/ia-bookmarks-list.js
@@ -40,7 +40,10 @@ export class IABookmarksList extends LitElement {
   }
 
   updated(changed) {
-    console.log('canged', changed);
+    const activeBookmarkChanged = changed.has('activeBookmarkID');
+    if (activeBookmarkChanged && (this.activeBookmarkID !== undefined)) { /* can be zero */
+      this.shadowRoot.querySelector('.active').scrollIntoView();
+    }
     // this.sortedBookmarks = this.sortBookmarks(this.bookmarks);
   }
 

--- a/src/ia-bookmarks-list.js
+++ b/src/ia-bookmarks-list.js
@@ -15,9 +15,11 @@ export class IABookmarksList extends LitElement {
       activeBookmarkID: { type: Number },
       bookmarkColors: { type: Array },
       defaultBookmarkColor: { type: Object },
-      bookmarks: { type: Array },
+      bookmarks: { type: Object },
       editedBookmark: { type: Object },
       renderHeader: { type: Boolean },
+
+      sortedBookmarks: { type: Array },
     };
   }
 
@@ -26,9 +28,20 @@ export class IABookmarksList extends LitElement {
     this.activeBookmarkID = undefined;
     this.bookmarkColors = [];
     this.defaultBookmarkColor = {};
-    this.bookmarks = [];
+    this.bookmarks = {};
+    this.sortedBookmarks = [];
     this.editedBookmark = {};
     this.renderHeader = false;
+  }
+
+  firstUpdated() {
+    this.sortedBookmarks = this.sortBookmarks(this.bookmarks);
+    console.log('FIRST UPDATED', this.sortedBookmarks);
+  }
+
+  updated(changed) {
+    console.log('canged', changed);
+    // this.sortedBookmarks = this.sortBookmarks(this.bookmarks);
   }
 
   emitEditEvent(e, bookmark) {
@@ -157,11 +170,24 @@ export class IABookmarksList extends LitElement {
     </header>`;
   }
 
+  sortBookmarks() {
+    const sortedKeys = Object.keys(this.bookmarks).sort((a, b) => {
+      if (+a > +b) { return 1; }
+      if (+a < +b) { return -1; }
+      return 0;
+    });
+
+    const sortedBookmarks = sortedKeys.map(key => this.bookmarks[key]);
+
+    return sortedBookmarks;
+  }
+
   render() {
+    console.log('RENDER, sortedbookmarker', this.sortedBookmarks);
     return html`
       ${this.renderHeader ? this.headerSection : nothing}
       <ul>
-        ${this.bookmarks.length ? repeat(this.bookmarks, bookmark => bookmark.id, this.bookmarkItem.bind(this)) : nothing}
+        ${this.sortedBookmarks.length ? repeat(this.sortedBookmarks, bookmark => bookmark.id, this.bookmarkItem.bind(this)) : nothing}
         <div class="separator"></div>
       </ul>
     `;

--- a/src/styles/ia-bookmarks-list.js
+++ b/src/styles/ia-bookmarks-list.js
@@ -120,8 +120,6 @@ button.add-bookmark {
 }
 
 ia-bookmark-edit {
-  --saveButtonColor: #538bc5;
-  --deleteButtonColor: #d33630;
   margin: .5rem .5rem .3rem .6rem;
 }
 


### PR DESCRIPTION
keeping display as pure render as possible
- keep default draw at a bare minimum - only draw list if bookmarks are available
- no more "add bookmark" button & its properties
- uses bookmarks hash map as primary data source - like main controller
- sorts bookmarks at render to display in ascending order
- updates tests to use bookmarks hash map
- add tests to account for sort-at-render & basic default view (of none)
